### PR TITLE
Add a script to delete stale branches

### DIFF
--- a/delete.sh
+++ b/delete.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for branch in $(git branch -a | sed 's/^\s*//;s/\*//;s/^remotes\///' | grep -v 'master$'); do               
+  if [[ "$(git log $branch --since "12 months ago" | wc -l)" -eq 0 ]]; then
+    local_branch_name=$(echo "$branch" | sed 's/origin\///')
+    echo $local_branch_name
+    git branch -D $local_branch_name 
+    git push origin --delete $local_branch_name 
+  fi
+done


### PR DESCRIPTION
Usage:
```
chmod +x delete.sh
./delete.sh
```
Currently set to delete branches that have not had new contributions in the last 12 months. 

When ran on the main repo, the 389 branches → 90 branches